### PR TITLE
fix auth verification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,8 @@ import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import BpErrorPage from './BpErrorPage';
 
 import MyLayout from './BpLayout';
-import { bpTheme } from './bpTheme';
+import BpLoading from './BpLoading';
+import { bpTheme, BP_COLOR } from './bpTheme';
 
 import account from './operations/account';
 import { Configuration } from './operations/configurations';
@@ -23,6 +24,7 @@ import { loginSuccessRelUrl } from './security/login-redirection-urls';
 
 import LoginPage from './security/LoginPage';
 import LoginSuccessPage from './security/LoginSuccessPage';
+import useAuthentication from './utils/useAuthentication';
 
 export const BpAdmin = () => (
   <Admin
@@ -53,13 +55,14 @@ export const BpAdmin = () => (
 
 const App = () => {
   const accessToken = getCachedAccessToken();
-
+  const { isLoading, isAuthenticated } = useAuthentication();
   return (
     <BrowserRouter>
       <Routes>
+        {isLoading && <Route path='*' element={<BpLoading />} />}
         <Route exact path={loginSuccessRelUrl} element={<LoginSuccessPage />} />
-        <Route exact path='/login' element={!accessToken ? <LoginPage /> : <Navigate to='/' />} />
-        <Route exact path='*' element={accessToken ? <BpAdmin /> : <Navigate to='/login' />} />
+        <Route exact path='/login' element={!isAuthenticated ? <LoginPage /> : <Navigate to='/' />} />
+        <Route exact path='*' element={isAuthenticated ? <BpAdmin /> : <Navigate to='/login' />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/BpLoading.js
+++ b/src/BpLoading.js
@@ -1,0 +1,14 @@
+import { Box, CircularProgress } from '@mui/material';
+import { BP_COLOR } from './bpTheme';
+
+const styles = {
+  BG: { width: '100vw', height: '90vh', margin: 0, padding: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' },
+};
+
+const BpLoading = () => (
+  <Box sx={styles.BG}>
+    <CircularProgress sx={{ color: BP_COLOR[20] }} size={60} />
+  </Box>
+);
+
+export default BpLoading;

--- a/src/__tests__/Transaction.cy.js
+++ b/src/__tests__/Transaction.cy.js
@@ -62,7 +62,7 @@ describe(specTitle('Transactions'), () => {
     cy.contains('Recette');
     cy.contains('Trésorerie');
     cy.contains('30');
-    cy.contains('10');
+    cy.contains('20');
     cy.contains('40');
     cy.get('#date').type('2022-01');
     cy.contains('12');

--- a/src/utils/useAuthentication.ts
+++ b/src/utils/useAuthentication.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import authProvider from 'src/providers/auth-provider';
+
+/**
+ * function that check is the user is authenticated or not (react admin has the same function but it seems not work)
+ *
+ */
+const useAuthentication = () => {
+  const [{ isLoading, isAuthenticated }, setState] = useState({ isLoading: true, isAuthenticated: false });
+
+  useEffect(() => {
+    setState({ isLoading: true, isAuthenticated: false });
+    authProvider
+      .checkAuth()
+      .then(() => {
+        setState({ isLoading: false, isAuthenticated: true });
+      })
+      .catch(() => {
+        authProvider.logout();
+        setState({ isLoading: false, isAuthenticated: false });
+      });
+  }, []);
+
+  return { isLoading, isAuthenticated };
+};
+
+export default useAuthentication;


### PR DESCRIPTION
The dashboard goes back and forth on the **/transaction** endpoint when you reconnect with an expired token

I added a loading (`<BpLoading />`) to have time to check the token and redirect the user

![Screenshot from 2022-12-01 12-05-59](https://user-images.githubusercontent.com/95756837/205011596-15e63743-dfbf-4fc9-aa4b-5561dc9dd952.png)
