### PR TITLE
fix(374): 'dummy on purpose' while waiting for connection confirmation

### DIFF
--- a/src/security/LoginPage.js
+++ b/src/security/LoginPage.js
@@ -21,7 +21,7 @@ const BpLoginPage = () => {
     } = await securityApi().initiateAuth({
       state: uuidv4(),
       // as we don'h handle phone prefixes (eg MG and FR), Swan will re-ask us phone anyway ==> use dummy
-      phone: 'dummy on purpose',
+      phone: 'numéro renseigné',
       redirectionStatusUrls: loginRedirectionUrls,
     });
     redirect(redirectionUrl);


### PR DESCRIPTION
The default phone number `'dummy on purpose'` is displayed after entering the phone number.